### PR TITLE
Allow passing identifiers to lua_string!

### DIFF
--- a/gmod/src/lua/mod.rs
+++ b/gmod/src/lua/mod.rs
@@ -37,11 +37,14 @@ pub enum LuaError {
 	Unknown(i32),
 }
 
-/// Converts a string literal to a Lua-compatible NUL terminated string at compile time.
+/// Converts a string literal or identifier to a Lua-compatible NUL terminated string at compile time.
 #[macro_export]
 macro_rules! lua_string {
 	( $str:literal ) => {
 		$crate::cstr::cstr!($str).as_ptr()
+	};
+	( $name:ident ) => {
+		concat!(stringify!($name), "\0").as_ptr() as *const i8
 	};
 }
 


### PR DESCRIPTION
As title, allows passing identifiers as well as string literals, such as is used in [gm_sysinfo](https://github.com/JoshPiper/gm_sysinfo/blob/main/src/lib.rs#L126-L132)

Unfortunately, however, the macro has not been tested to ensure operability, however, similar code is already used in larger macros, so it shouldn't be an issue.
