### PR TITLE
fix: :heavy_plus_sign: Switch detour to retour (fork)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,22 +47,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "detour"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3c83fabcc3bc336e19320c13576ea708a15deec201d6b879b7ad1b92734d7b9"
-dependencies = [
- "cfg-if",
- "generic-array",
- "lazy_static",
- "libc",
- "libudis86-sys",
- "mmap-fixed",
- "region",
- "slice-pool",
-]
-
-[[package]]
 name = "fn_abi"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -114,7 +98,6 @@ dependencies = [
  "cfg_table",
  "cstr",
  "ctor",
- "detour",
  "fn_abi",
  "fn_has_this",
  "fn_type_alias",
@@ -122,6 +105,7 @@ dependencies = [
  "lazy_static",
  "libloading",
  "null_fn",
+ "retour",
  "skidscan",
 ]
 
@@ -132,16 +116,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "kernel32-sys"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
-dependencies = [
- "winapi 0.2.8",
- "winapi-build",
 ]
 
 [[package]]
@@ -163,7 +137,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f84d96438c15fcd6c3f244c8fce01d1e2b9c6b5623e9c711dc9286d8fc92d6a"
 dependencies = [
  "cfg-if",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -186,14 +160,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "mmap-fixed"
-version = "0.1.5"
+name = "mmap-fixed-fixed"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27c1ae264d6343d3b4079549f6bc9e6d074dc4106cb1324c7753c6ce11d07b21"
+checksum = "0681853891801e4763dc252e843672faf32bcfee27a0aa3b19733902af450acc"
 dependencies = [
- "kernel32-sys",
  "libc",
- "winapi 0.2.8",
+ "winapi",
 ]
 
 [[package]]
@@ -237,14 +210,30 @@ dependencies = [
 
 [[package]]
 name = "region"
-version = "2.2.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877e54ea2adcd70d80e9179344c97f93ef0dffd6b03e1f4529e6e83ab2fa9ae0"
+checksum = "76e189c2369884dce920945e2ddf79b3dff49e071a167dd1817fa9c4c00d512e"
 dependencies = [
  "bitflags",
  "libc",
  "mach",
- "winapi 0.3.9",
+ "winapi",
+]
+
+[[package]]
+name = "retour"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a83f9f8fa2d02a11cb18d157ca898f1d8a197c19b084ef8d0a8da256a5c58935"
+dependencies = [
+ "cfg-if",
+ "generic-array",
+ "lazy_static",
+ "libc",
+ "libudis86-sys",
+ "mmap-fixed-fixed",
+ "region",
+ "slice-pool",
 ]
 
 [[package]]
@@ -261,7 +250,7 @@ checksum = "60c2b7c0d9358c69c16b05037d80ffc810655ea7a2625beeb8af8a8b37126768"
 dependencies = [
  "libc",
  "skidscan-macros",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -346,12 +335,6 @@ checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
 
 [[package]]
 name = "winapi"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
-
-[[package]]
-name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
@@ -359,12 +342,6 @@ dependencies = [
  "winapi-i686-pc-windows-gnu",
  "winapi-x86_64-pc-windows-gnu",
 ]
-
-[[package]]
-name = "winapi-build"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 
 [[package]]
 name = "winapi-i686-pc-windows-gnu"

--- a/gmod/Cargo.toml
+++ b/gmod/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["api-bindings", "external-ffi-bindings", "game-development", "deve
 
 [features]
 default = ["hax"]
-hax = ["ctor", "skidscan", "detour", "fn_type_alias", "fn_abi", "cfg_table", "null_fn", "fn_has_this"]
+hax = ["ctor", "skidscan", "retour", "fn_type_alias", "fn_abi", "cfg_table", "null_fn", "fn_has_this"]
 gmcl = ["gmod-macros/gmcl"]
 
 [dependencies]
@@ -21,7 +21,7 @@ libloading = "0"
 cstr = "0"
 lazy_static = "1"
 
-detour = { version = "0", optional = true }
+retour = { version = "0", optional = true }
 ctor = { version = "0", optional = true }
 skidscan = { version = "2", optional = true }
 

--- a/gmod/Cargo.toml
+++ b/gmod/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gmod"
-version = "16.0.2"
+version = "17.0.0"
 authors = ["William Venner <william@venner.io>"]
 edition = "2021"
 license = "MIT"

--- a/gmod/src/lib.rs
+++ b/gmod/src/lib.rs
@@ -23,7 +23,7 @@ mod haxports {
 	#[cfg(target_os = "macos")]
 	compile_error!("Sigscanning is currently not supported on MacOS, please disable the `hax` feature on gmod-rs using `default-features = false` to make a normal module");
 
-	pub use detour;
+	pub use retour as detour;
 	pub use ctor::{ctor as dllopen, dtor as dllclose};
 
 	pub use fn_type_alias::*;


### PR DESCRIPTION
Detour is no longer maintained (https://github.com/darfink/detour-rs/pull/41), the community has forked it and made it work on nightly as retour.

This switch is required as detour no longer compiles on nightly.