### PR TITLE
Remove #![feature(c_unwind)] because it's stabilized

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,7 +93,7 @@ dependencies = [
 
 [[package]]
 name = "gmod"
-version = "16.0.2"
+version = "17.0.0"
 dependencies = [
  "cfg_table",
  "cstr",

--- a/README.md
+++ b/README.md
@@ -13,5 +13,3 @@ A swiss army knife for creating binary modules for Garry's Mod in Rust.
 # Nightly requirement
 
 Currently, this crate requires the Rust Nightly compiler to be used.
-
-This is because of the nature of Rust <-> C FFI (which is used extensively in this crate for interfacing with Lua) and the undefined behaviour that occurs when Lua performs long jumps out of functions during errors, or when Rust panics and unwinds out of a foreign stack frame. The [`C-unwind` ABI](https://rust-lang.github.io/rfcs/2945-c-unwind-abi.html) is used to prevent this undefined behaviour.

--- a/examples/my-first-binary-module/src/lib.rs
+++ b/examples/my-first-binary-module/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(c_unwind)]
-
 #[macro_use] extern crate gmod;
 
 #[gmod13_open]

--- a/examples/printing-to-console/src/lib.rs
+++ b/examples/printing-to-console/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(c_unwind)]
-
 use gmod::gmcl::override_stdout;
 use gmod::lua::State;
 

--- a/gmod/src/lib.rs
+++ b/gmod/src/lib.rs
@@ -3,7 +3,6 @@
 #![allow(clippy::missing_safety_doc)]
 #![allow(clippy::result_unit_err)]
 
-#![feature(c_unwind)]
 #![feature(thread_id_value)]
 
 #![cfg_attr(feature = "gmcl", feature(internal_output_capture))]

--- a/tests/userdata/src/lib.rs
+++ b/tests/userdata/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(c_unwind)]
-
 #[macro_use]
 extern crate gmod;
 


### PR DESCRIPTION
```warning: the feature `c_unwind` has been stable since 1.81.0 and no longer requires an attribute to enable```

I've not removed the nightly requirement, because retour seems to have an issue at compiling with the used version 0.1 and I don't know, if an update of that crate could cause further problems.
```Compiling retour v0.1.0
error[E0554]: `#![feature]` may not be used on the stable release channel
 --> /home/hiraku/.cargo/registry/src/index.crates.io-6f17d22bba15001f/retour-0.1.0/src/lib.rs:4:3
  |
4 |   feature(unboxed_closures, abi_thiscall, tuple_trait)
  |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |
  = help: the feature `abi_thiscall` has been stable since `1.73.0` and no longer requires an attribute to enable

For more information about this error, try `rustc --explain E0554`.
error: could not compile `retour` (lib) due to 1 previous error```