### PR TITLE
fix fastcall

### DIFF
--- a/gmod/Cargo.toml
+++ b/gmod/Cargo.toml
@@ -21,7 +21,7 @@ libloading = "0"
 cstr = "0"
 lazy_static = "1"
 
-retour = { version = "0", optional = true }
+retour = { version = "0.4.0-alpha.4", features = ["thiscall-abi"], optional = true }
 ctor = { version = "0", optional = true }
 skidscan = { version = "2", optional = true }
 


### PR DESCRIPTION
keep getting errors when compiling something with "hax" feature enabled:
" **fastcall**/**win64** is not a supported ABI for the current target (from retour)"
alpha version + feature fastcall-abi fix that