### PR TITLE
Fix small Lua edge cases

### DIFF
--- a/gmod/src/lua/lua_state.rs
+++ b/gmod/src/lua/lua_state.rs
@@ -28,10 +28,10 @@ pub struct LuaState(pub *mut std::ffi::c_void);
 impl LuaState {
 	pub unsafe fn new() -> Result<Self, LuaError> {
 		let lua = (LUA_SHARED.lual_newstate)();
-		(LUA_SHARED.lual_openlibs)(lua);
 		if lua.is_null() {
 			Err(LuaError::MemoryAllocationError)
 		} else {
+			(LUA_SHARED.lual_openlibs)(lua);
 			Ok(lua)
 		}
 	}

--- a/gmod/src/lua/mod.rs
+++ b/gmod/src/lua/mod.rs
@@ -97,7 +97,7 @@ macro_rules! lua_stack_guard {
 			let ret = (|| $code)();
 			if $lua.get_top() != $elem {
 				$lua.dump_stack();
-				panic!("Stack is dirty! Expected the stack to have ", $elem, " (fixed size) elements, but it has {}!", $lua.get_top());
+				panic!("Stack is dirty! Expected the stack to have {} (fixed size) elements, but it has {}!", $elem, $lua.get_top());
 			}
 			ret
 		}


### PR DESCRIPTION
﻿Fixes two small Lua edge cases:

- fixed-size lua_stack_guard panic formatting now compiles
- LuaState::new checks luaL_newstate before opening libs, avoiding a null state call on allocation failure

Checks:
- rustc smoke for the fixed panic format
- cargo +stable check -p gmod-macros --offline

Full workspace check needs nightly and cfg_table in cache; nightly install failed locally before download completed.
